### PR TITLE
transactions: make the CpfpTransaction a simple newtype

### DIFF
--- a/src/transactions/mod.rs
+++ b/src/transactions/mod.rs
@@ -439,29 +439,10 @@ impl<T: inner_mut::PrivateInnerMut + fmt::Debug + Clone + PartialEq> RevaultTran
         <T as PrivateInnerMut>::from_psbt_serialized(raw_psbt)
     }
 
+    /// Return the absolute fees this transaction is paying.
     fn fees(&self) -> u64 {
-        let mut value_in: u64 = 0;
-        for i in self.psbt().inputs.iter() {
-            value_in = value_in
-                .checked_add(
-                    i.witness_utxo
-                        .as_ref()
-                        .expect("A witness utxo is always set")
-                        .value,
-                )
-                .expect("PSBT bug: overflow while computing spent coins value");
-        }
-
-        let mut value_out: u64 = 0;
-        for o in self.psbt().global.unsigned_tx.output.iter() {
-            value_out = value_out
-                .checked_add(o.value)
-                .expect("PSBT bug: overflow while computing created coins value");
-        }
-
-        value_in
-            .checked_sub(value_out)
-            .expect("We never create a transaction with negative fees")
+        // We always set witness_utxo, it can only be a bug we introduced with amounts.
+        utils::psbt_fees(self.psbt()).expect("Fee computation bug: overflow")
     }
 
     /// Get the inner unsigned transaction id

--- a/src/transactions/utils.rs
+++ b/src/transactions/utils.rs
@@ -300,3 +300,22 @@ pub fn p2wsh_input_index(psbt: &Psbt) -> Option<usize> {
             == Some(true)
     })
 }
+
+/// Returns the absolute fees paid by a PSBT.
+///
+/// Returns None if:
+/// - A witness UTxO isn't set in one of the PSBT inputs
+/// - There an overflow or underflow when computing the fees
+pub fn psbt_fees(psbt: &Psbt) -> Option<u64> {
+    let mut value_in: u64 = 0;
+    for i in psbt.inputs.iter() {
+        value_in = value_in.checked_add(i.witness_utxo.as_ref()?.value)?;
+    }
+
+    let mut value_out: u64 = 0;
+    for o in psbt.global.unsigned_tx.output.iter() {
+        value_out = value_out.checked_add(o.value)?
+    }
+
+    value_in.checked_sub(value_out)
+}


### PR DESCRIPTION
We don't need to add signatures to it ourselves, don't need to finalize
it, don't need to (de)serialize it. Actually we need none of the
functionalities provided by the RevaultTransaction trait.

Therefore just make the CpfpTransaction a simple newtype over a Psbt.

No single modification to `revaultd` is needed :).