### PR TITLE
scripts: limit the number of stakeholders and managers to 20

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,13 @@ impl From<miniscript::Error> for ScriptCreationError {
     }
 }
 
+// TODO: Remove this manual implementation of PartialEq once the trait is derivable for miniscript crate type fields.
+impl PartialEq for ScriptCreationError {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
+    }
+}
+
 impl error::Error for ScriptCreationError {}
 
 /// Error when creating a Revault Bitcoin transaction output

--- a/src/transactions/mod.rs
+++ b/src/transactions/mod.rs
@@ -827,7 +827,7 @@ mod tests {
         ));
         // 100 BTC
         derive_transactions(
-            38,
+            MAX_STAKEHOLDERS,
             5,
             csv,
             deposit_prevout,
@@ -839,12 +839,12 @@ mod tests {
             &secp,
         )
         .expect(&format!(
-            "Tx chain with 38 stakeholders, 5 manager, {} csv, 100_000_000_000 deposit",
-            csv
+            "Tx chain with {} stakeholders, 5 manager, {} csv, 100_000_000_000 deposit",
+            MAX_STAKEHOLDERS, csv
         ));
         // 100 BTC, no cosigning server
         derive_transactions(
-            38,
+            MAX_STAKEHOLDERS,
             5,
             csv,
             deposit_prevout,
@@ -856,8 +856,8 @@ mod tests {
             &secp,
         )
         .expect(&format!(
-            "Tx chain with 38 stakeholders, 5 manager, {} csv, 100_000_000_000 deposit, no cosig",
-            csv
+            "Tx chain with {} stakeholders, 5 manager, {} csv, 100_000_000_000 deposit, no cosig",
+            MAX_STAKEHOLDERS, csv
         ));
     }
 


### PR DESCRIPTION
Issue: revault/practical-revault#110

WIP because I haven't ran the revaultd integration tests.

I don't understand why managers are included as stakeholders here (previously hitting stakeholder limit): https://github.com/revault/revault_tx/blob/c7e3e29ed37c06196ea241015cfe92c28d1957bf/src/scripts.rs#L1506
